### PR TITLE
docs(workflow): add focus timer app dry run record

### DIFF
--- a/dryrun/focus-timer-app/BACKLOG.md
+++ b/dryrun/focus-timer-app/BACKLOG.md
@@ -1,0 +1,31 @@
+# BACKLOG: Focus Timer App
+
+**Date:** 2026-02-19
+
+## Epics
+1. **Core Timer System:** Ensure the 25/5 minute cycles work flawlessly.
+2. **Task Management:** Allow users to manage what they are focusing on.
+
+## Issues / User Stories
+
+### Focus Timer
+- **#1 [Feature] Create Pomodoro Timer**
+  - **DoD:** Timer counts down from 25:00. Shows remaining time on screen. Plays a sound when finished.
+- **#2 [Feature] Create Break Timer**
+  - **DoD:** After 25 minutes, automatically switch or prompt to switch to a 5-minute break timer.
+
+### Task List
+- **#3 [Feature] Add/Remove/Edit Tasks**
+  - **DoD:** UI has an input field. Pressing Enter adds to a list below. Can delete tasks.
+- **#4 [Feature] Link Timer to Task**
+  - **DoD:** User can select an active task. When a Pomodoro completes, a checkmark or session counter is incremented next to the task.
+
+### Data Persistence
+- **#5 [Feature] Save State to LocalStorage**
+  - **DoD:** Reloading the page retains task list and session counts.
+
+## Priorities (MoSCoW)
+- **Must Have:** #1, #2, #3
+- **Should Have:** #4, #5
+- **Could Have:** Settings to change timer duration
+- **Won't Have:** Cloud Sync

--- a/dryrun/focus-timer-app/IMPLEMENTATION_PLAN.md
+++ b/dryrun/focus-timer-app/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,24 @@
+# IMPLEMENTATION PLAN: Focus Timer App
+
+**Date:** 2026-02-19
+
+## Sprint 1: Core MVP (Days 1-3)
+**Goal:** Have a working timer and basic task list without persistence.
+
+### Tasks to Complete
+1. **[SEC-1]** Ensure CSP meta tags are in `index.html`.
+2. **[#1]** Create UI and logic for 25-minute Pomodoro Timer.
+3. **[#2]** Create logic to switch to 5-minute Break Timer.
+4. **[#3]** Build the Task List UI (Add, Delete).
+5. **[SEC-2]** Implement text node creation for task generation to prevent XSS.
+
+## Sprint 2: Data Persistence & Polish (Days 4-5)
+**Goal:** Save data, add polish, and meet all MVP requirements.
+
+### Tasks to Complete
+1. **[#4]** Link Timer completions to the active selected task.
+2. **[#5]** Implement `StorageManager` to save tasks and pomodoro counts to `localStorage`.
+3. **[SEC-3]** Add UI tooltip warning about LocalStorage limits/cache clearing.
+
+## Dependencies & Blockers
+- None identified. Sprint 1 must be completed before Sprint 2.

--- a/dryrun/focus-timer-app/PRODUCT_VISION.md
+++ b/dryrun/focus-timer-app/PRODUCT_VISION.md
@@ -1,0 +1,32 @@
+# PRODUCT VISION: Focus Timer App
+
+**Date:** 2026-02-19
+**Product:** Focus Timer (Pomodoro approach)
+
+## 1. What is the core problem this solves?
+Users get easily distracted and need a structured way to maintain focus using the Pomodoro technique (25 min work, 5 min break).
+
+## 2. Who is the target user?
+Students, remote workers, and freelancers looking to improve productivity.
+
+## 3. What are the core features (MVP)?
+1. **Timer:** Start, pause, and reset a 25-minute focus timer and a 5-minute break timer.
+2. **Task List:** Add, edit, and mark tasks as done.
+3. **Session Tracking:** Count how many focus sessions were completed for a given task.
+
+## 4. What are the key user flows?
+- User opens the app -> sees the timer and the task list.
+- User adds a task "Write report" -> Selects the task -> Clicks "Start Timer".
+- Timer counts down from 25:00.
+- When timer ends -> Sound plays -> Session count for task increments -> Break timer starts.
+
+## 5. Are there any design or technical constraints?
+- Must work offline (Local Storage).
+- Responsive UI (Mobile and Desktop web).
+- Dark mode by default for less eye strain.
+
+## 6. Success Metrics
+- Users complete at least 2 pomodoro sessions per visit.
+- 0 data loss on page reload.
+
+*(Note: In a real scenario, this would consist of 21 questions asked by the PM Agent. For this dry test, we summarize the essence.)*

--- a/dryrun/focus-timer-app/SECURITY_BACKLOG.md
+++ b/dryrun/focus-timer-app/SECURITY_BACKLOG.md
@@ -1,0 +1,14 @@
+# SECURITY BACKLOG: Focus Timer App
+
+**Date:** 2026-02-19
+
+## Security Tickets
+
+- **#SEC-1 [Security] Enforce Content Security Policy (CSP)**
+  - **DoD:** Meta tag or headers configured to prevent inline scripts or untrusted external scripts.
+
+- **#SEC-2 [Security] Sanitize Task Input**
+  - **DoD:** Any user-provided task name is properly escaped before being rendered. Use `document.createTextNode` instead of innerHTML.
+
+- **#SEC-3 [Privacy] LocalStorage Warning**
+  - **DoD:** A small info icon alerts users that data is local and clearing cache will wipe tasks.

--- a/dryrun/focus-timer-app/SECURITY_RELEASE_SIGNOFF.md
+++ b/dryrun/focus-timer-app/SECURITY_RELEASE_SIGNOFF.md
@@ -1,0 +1,14 @@
+# SECURITY RELEASE SIGN-OFF
+
+**Date:** 2026-02-19
+**Product:** Focus Timer
+**Sign-off By:** Security Agent (Simulated)
+
+## Release Gate C Checklist
+- [x] All P0/P1 vulnerabilities mitigated.
+- [x] Security Review Report completed and approved.
+- [x] Code contains no hardcoded secrets or malicious dependencies.
+- [x] XSS vectors correctly neutralized.
+
+## Decision
+**GO** for release. (Approved)

--- a/dryrun/focus-timer-app/SECURITY_REVIEW_REPORT.md
+++ b/dryrun/focus-timer-app/SECURITY_REVIEW_REPORT.md
@@ -1,0 +1,14 @@
+# SECURITY REVIEW REPORT
+
+**Date:** 2026-02-19
+**Product:** Focus Timer
+**Reviewer:** Lead Dev / Security Agent
+
+## Findings
+
+1. **[PASS] CSP Meta Tag:** Verified present in `index.html`. No inline scripts detected in codebase. (Mitigates P1)
+2. **[PASS] DOM Rendering:** Verified `app.js` line 42 uses `document.createTextNode()` for rendering user tasks. XSS vector eliminated. (Mitigates P1)
+3. **[PASS] LocalStorage:** Verified data saving works. Tooltip added for privacy warning. (Mitigates P2)
+
+## Conclusion
+Code meets all security requirements. 0 Open P0/P1 risks. Approved for QA validation.

--- a/dryrun/focus-timer-app/SECURITY_THREAT_MODEL.md
+++ b/dryrun/focus-timer-app/SECURITY_THREAT_MODEL.md
@@ -1,0 +1,27 @@
+# SECURITY THREAT MODEL
+
+**Date:** 2026-02-19
+**Product:** Focus Timer
+
+## 1. Attack Surface
+- **LocalStorage Data:** The primary data store for user tasks and timer history.
+- **Client-Side Scripting:** The app logic sits entirely in the client's browser.
+
+## 2. Sensitive Data Paths
+- Task List names (could contain user PII).
+- Handled exclusively via LocalStorage; no network transmission.
+
+## 3. Threat Assessment & Mitigations
+
+### P1: Cross-Site Scripting (XSS)
+- **Risk:** Malicious user input in the "Add Task" field could execute scripts if rendered without sanitization.
+- **Mitigation:** Use `textContent` instead of `innerHTML` when rendering task names in the DOM.
+
+### P2: Data Loss
+- **Risk:** User clears browser data or uses incognito mode, losing all tasks.
+- **Mitigation:** Clearly inform the user that data is device-local. Suggest periodic JSON export if the feature is added later.
+
+## 4. Security Gate A Status
+✅ XSS mitigated by strict DOM manipulation rules.
+✅ No sensitive data transmitted over network.
+✅ Ready for implementation backlog.

--- a/dryrun/focus-timer-app/TECH_STRATEGY.md
+++ b/dryrun/focus-timer-app/TECH_STRATEGY.md
@@ -1,0 +1,21 @@
+# TECH STRATEGY: Focus Timer App
+
+**Date:** 2026-02-19
+**Product:** Focus Timer
+
+## Proposed Tech Stack (Option C Chosen)
+- **Frontend:** HTML5, CSS3 (Vanilla), JavaScript (ES6+ Modules)
+- **Storage:** LocalStorage API
+- **Deployment:** GitHub Pages or direct file execution
+
+## Architecture
+- `index.html`: Main UI shell.
+- `styles.css`: Dark mode by default, CSS variables for theming.
+- `app.js`: Contains Timer logic, Task management logic, and LocalStorage sync.
+
+## Rationale
+Since this is an MVP that requires no backend, keeping it dependency-free allows for the fastest iteration and lowest maintenance overhead.
+
+## API / Interfaces
+- `StorageManager`: Handles `getItem` and `setItem` for `tasks` and `pomodoros_completed`.
+- `TimerEngine`: Emits `tick` and `complete` events.

--- a/dryrun/focus-timer-app/VALIDATION_REPORT.md
+++ b/dryrun/focus-timer-app/VALIDATION_REPORT.md
@@ -1,0 +1,21 @@
+# VALIDATION REPORT
+
+**Date:** 2026-02-19
+**Product:** Focus Timer
+**QA Agent:** Automated / Simulated
+
+## Test Execution Summary
+- **Test Environment:** Chrome 120 (macOS), Safari iOS 17 (Simulator)
+- **Status:** All flows passed.
+
+## Critical User Flows Tested
+1. **[PASS] Timer Cycle:** Started 25-minute timer. Verified it reaches 0:00, plays sound, and switches to 5-minute break mode.
+2. **[PASS] Task Addition:** Typed "Buy groceries" and hit Enter. Task appeared in the list below.
+3. **[PASS] Task Linking:** Selected "Buy groceries", ran a 1-minute mock timer. Verified completion counter incremented to 1.
+4. **[PASS] Data Persistence:** Reloaded the page. Verified "Buy groceries" with count 1 was still present.
+
+## Known Issues (Minor)
+- None.
+
+## Conclusion
+Feature complete, functioning flawlessly according to MVP spec. Approved for release.


### PR DESCRIPTION
Adding the generated artifacts from the AI Dev Flow dry run to keep a historical record of the expected outputs.